### PR TITLE
Make app responsive for small screens (<500px)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 * {
     box-sizing: border-box;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 html {

--- a/src/pages/AuthPage/AuthContainer/AuthContainerStyles.js
+++ b/src/pages/AuthPage/AuthContainer/AuthContainerStyles.js
@@ -6,10 +6,18 @@ export const StyledAuthWrapper = styled.section`
 `;
 
 export const StyledAuthHeading1 = styled.h1`
-  font-size: 5rem;
+  font-size: 3rem;
   margin-bottom: 1rem;
+
+  @media screen and (min-width: 500px) {
+    font-size: 5rem;
+  }
 `;
 
 export const StyledAuthHeading2 = styled.h2`
-  font-size: 2rem;
+  font-size: 1.7rem;
+
+  @media screen and (min-width: 500px) {
+    font-size: 2rem;
+  }
 `;

--- a/src/pages/AuthPage/AuthContainer/ButtonGroup/ButtonGroupStyles.js
+++ b/src/pages/AuthPage/AuthContainer/ButtonGroup/ButtonGroupStyles.js
@@ -3,20 +3,29 @@ import styled from "styled-components";
 export const StyledButtonGroupContainer = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 310px;
+  width: 20rem;
+
+  @media screen and (min-width: 500px) {
+    width: 19rem;
+  }
 `;
 
 export const StyledAuthButton = styled.button`
-  margin: 6px;
-  padding: 11px;
-  border-radius: 30px;
-  font-size: 0.8rem;
+  margin: 0.375rem;
+  border-radius: 1.875rem;
   border: 0;
   font-weight: 600;
+  font-size: 0.99rem;
+  padding: 0.625rem;
+
+  @media screen and (min-width: 500px) {
+    padding: 0.688rem;
+    font-size: 0.8rem;
+  }
 `;
 
 export const StyledOrDivider = styled.div`
-  margin: 10px 0;
+  margin: 0.625rem 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -24,8 +33,8 @@ export const StyledOrDivider = styled.div`
 
 export const StyledLine = styled.span`
   background-color: rgb(47, 51, 54);
-  height: 1px;
-  width: 10px;
+  height: 0.063rem;
+  width: 0.625rem;
   flex-grow: 1;
   margin: 0 0.5rem;
 `;
@@ -36,17 +45,40 @@ export const StyledCreateAccount = styled(StyledAuthButton)`
 `;
 
 export const StyledTermsOfService = styled.p`
-  font-size: 0.8rem;
   color: gray;
   margin-top: 0;
+  font-size: 0.7rem;
+
+  @media screen and (min-width: 500px) {
+    font-size: 0.8rem;
+  }
 `;
 
 export const StyledAlreadyHaveAccount = styled.h3`
-  margin-top: 3rem;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+
+  @media screen and (max-width: 500px) {
+    font-size: large;
+  }
+
+  @media screen and (min-width: 500px) {
+    margin-top: 3rem;
+  }
 `;
 
 export const StyledSignIn = styled(StyledAuthButton)`
   color: rgb(29, 155, 240);
   background-color: inherit;
-  border: 0.001px solid rgb(83, 100, 113);
+  border: 0.001rem solid rgb(83, 100, 113);
+  padding: 0.563rem;
+
+  @media screen and (max-width: 500px) {
+    font-size: 0.95rem;
+  }
+
+  @media screen and (min-width: 500px) {
+    font-size: inherit;
+    padding: 0.688rem;
+  }
 `;

--- a/src/pages/AuthPage/AuthPageStyles.js
+++ b/src/pages/AuthPage/AuthPageStyles.js
@@ -4,13 +4,28 @@ export const StyledAuthPageContainer = styled.div`
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  margin: 0 3rem;
+  margin: 0;
+
+  @media screen and (min-width: 500px) {
+    margin: 0 3rem;
+  }
 `;
 
 export const StyledHeroContainer = styled.main`
   display: flex;
-  align-items: center;
-  justify-content: space-evenly;
+  flex-direction: column;
+  justify-content: left;
+  align-items: flex-start;
   flex-grow: 1;
-  width: 100%;
+  padding-right: 6rem;
+  margin-left: 2rem;
+
+  @media screen and (min-width: 900px) {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-evenly;
+    width: 100%;
+    padding: inherit;
+    margin: inherit;
+  }
 `;

--- a/src/pages/AuthPage/Footer/FooterStyles.js
+++ b/src/pages/AuthPage/Footer/FooterStyles.js
@@ -3,14 +3,19 @@ import styled from "styled-components";
 export const StyledFooter = styled.footer`
   color: rgb(113, 118, 123);
   margin: 0.7rem 0;
-  font-size: 14px;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  row-gap: 0.313rem;
+  font-size: 0.813rem;
+
+  @media screen and (min-width: 500px) {
+    font-size: 0.875rem;
+  }
 `;
 
 export const StyledFooterItem = styled.div`
-  border: #000 solid 1px;
+  border: #000 solid 0.063rem;
   margin: 0 0.4rem;
   text-align: center;
 `;

--- a/src/pages/AuthPage/Logo/LogoStyles.js
+++ b/src/pages/AuthPage/Logo/LogoStyles.js
@@ -1,9 +1,16 @@
 import styled from "styled-components";
 
 export const StyledLogoWrapper = styled.div`
-  margin: 2rem 0;
-  width: 40%;
-  max-width: 400px;
+  width: 3.125rem;
+  margin: 2.5rem 0 0 0;
+  padding: 0;
+
+  @media screen and (min-width: 900px) {
+    margin: 2rem 0;
+    width: 40%;
+    max-width: 25rem;
+    padding: inherit;
+  }
 `;
 
 export const StyledLogoImage = styled.img`


### PR DESCRIPTION
### Purpose:
- Make app responsive for small screens such that it is viewable for viewports less than 500px in width.

### Changes:
- Added media-queries to AuthPageStyles.js, AuthContainerStyles.js, ButtonGroupStyle.js and LogoStyles.js.
- To resemble the design, this change moves the X logo above the buttons and reduces its size.
- Reduced the font size of the headers and footer items.
- Changed the font-family in App.css to resemble the design.
- Added the changes for medium screen responsiveness to deal with the logo.

### Screenshots:
*Zoom out your viewport to 50% for a better view*
#### Original design:
![twitter com__lang=en(iPhone 12 Pro)](https://github.com/iIqbalSazim/x-login/assets/144238479/972f6525-8861-43c7-9a5e-649916c1e851)

#### My current design:
![x-login_responsive-sm_current (iPhone 12 Pro)](https://github.com/iIqbalSazim/x-login/assets/144238479/85b6d74e-0ea0-493b-8b11-c09615a859bd)

#### My previous design:
![x-login_responsive-sm_previous](https://github.com/iIqbalSazim/x-login/assets/144238479/c680f455-3f1c-4c43-bc19-a17d8dfd2aa0)